### PR TITLE
GROSS-1358: SHA-pin GitHub Actions and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
   ignore:
     # Target a low version of FSharp.Core, for max compat
     - dependency-name: "FSharp.Core"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: "weekly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       with:
         fetch-depth: 0 # so that NerdBank.GitVersioning has access to history
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: 9.0.x
     - name: Build
@@ -32,11 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0 # so that NerdBank.GitVersioning has access to history
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: 9.0.x
       - name: Build
@@ -44,7 +44,7 @@ jobs:
       - name: Pack
         run: dotnet pack --configuration Release
       - name: Upload NuGet artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: nuget-package
           path: TypeEquality/bin/Release/TypeEquality.*.nupkg
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download NuGet artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: nuget-package
       - name: Check NuGet contents
@@ -66,7 +66,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: G-Research/common-actions/check-required-lite@main
+      - uses: G-Research/common-actions/check-required-lite@b6771a9cc351238f2964b3a2801aa655d72afcc4 # main
         with:
           needs-context: ${{ toJSON(needs) }}
 
@@ -81,17 +81,17 @@ jobs:
       contents: read
     steps:
       - name: Download NuGet artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: nuget-package
           path: downloaded
       - name: Obtain NuGet key
-        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544
+        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
         id: login
         with:
             user: ${{ secrets.NUGET_USER }}
       - name: Publish NuGet package
-        uses: G-Research/common-actions/publish-nuget@main
+        uses: G-Research/common-actions/publish-nuget@b6771a9cc351238f2964b3a2801aa655d72afcc4 # main
         with:
           package-name: TypeEquality
           nuget-key: ${{ steps.login.outputs.NUGET_API_KEY }}
@@ -106,7 +106,7 @@ jobs:
       contents: write
     steps:
       - name: Download NuGet artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: nuget-package
           path: downloaded
@@ -118,12 +118,12 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create GitHub release
-        uses: G-Research/common-actions/github-release@main
+        uses: G-Research/common-actions/github-release@b6771a9cc351238f2964b3a2801aa655d72afcc4 # main
         with:
           tag: ${{ steps.compute-tag.outputs.tag }}
           target-commitish: ${{ github.sha }}
@@ -134,7 +134,7 @@ jobs:
     needs: [nuget-pack]
     steps:
       - name: Download NuGet artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: nuget-package
           path: downloaded
@@ -145,7 +145,7 @@ jobs:
           TAG=$(basename "$FILE" .nupkg)
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
       - name: Create GitHub release
-        uses: G-Research/common-actions/github-release@main
+        uses: G-Research/common-actions/github-release@b6771a9cc351238f2964b3a2801aa655d72afcc4 # main
         with:
           tag: ${{ steps.compute-tag.outputs.tag }}
           target-commitish: ${{ github.sha }}


### PR DESCRIPTION
## What

Pin all GitHub Actions references to full commit SHAs (with trailing `# <version>` comments) and add the `github-actions` ecosystem to Dependabot (alongside the existing `nuget` ecosystem).

Ref: G-Research/gr-oss#1358

## Why

A mutable `@vN` / `@main` ref can be silently rewritten or compromised and is picked up immediately by every workflow run. Pinning to an immutable commit SHA closes that supply-chain risk; the trailing comment keeps the pin human-readable. Dependabot is enabled for github-actions so the pins are kept up to date.

## Notes

- `NuGet/login` was already pinned to a SHA but had no version comment; `# v1.1.0` was added.
- First-party `G-Research/common-actions/*` (check-required-lite, publish-nuget, github-release) were on `@main`; pinned to the current `main` SHA with a `# main` comment, matching the existing convention used in other G-Research repos (e.g. ApiSurface).
- Other actions pinned to their current major's SHA — a pin, not a version bump. Future upgrades are left to Dependabot.